### PR TITLE
Chore: .gitignore 에 Terraform 관련 파일 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,3 +273,9 @@ $RECYCLE.BIN/
 
 # Misc
 runserver.py
+
+
+# Terafform
+.terraform
+credential.tf
+.terraform.lock.hcl


### PR DESCRIPTION
vpc
subnet
security group
route table
route table : Route Table 생성
route association : route table을 subnet에 연결
route rule : route rule 생성
nat gateway
key pair
bastion
alb
위 구조로 테라폼 코드 모두 분리
data 블럭을 이용해 사용자가 입력한 리소스 이름의 정보를 불러와 필요한 의존성 주입
credential variable에 대한 정보는 다른 파일로 분리