### PR TITLE
Terraform 코드 파싱

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -279,3 +279,6 @@ runserver.py
 .terraform
 credential.tf
 .terraform.lock.hcl
+
+# Testing API
+/mcp-api-backend/api/v1/testapi.py

--- a/mcp-api-backend/api/v1/route.py
+++ b/mcp-api-backend/api/v1/route.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter
-from . import hello, adminInfo, instance
+from . import hello, adminInfo, instance, testapi
 
 
 api_router = APIRouter()
+api_router.include_router(testapi.router, prefix="/test", tags=["Test"])
 api_router.include_router(hello.router, prefix="/hello", tags=["Hello"])
 api_router.include_router(adminInfo.router, prefix="/adminInfo", tags=["AdminInfo"])
 api_router.include_router(instance.router, prefix="/instance", tags=["Instance"])

--- a/mcp-api-backend/api/v1/route.py
+++ b/mcp-api-backend/api/v1/route.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from . import hello, adminInfo, instance, testapi
+from . import hello, adminInfo, instance, testapi, stack
 
 
 api_router = APIRouter()
@@ -7,3 +7,4 @@ api_router.include_router(testapi.router, prefix="/test", tags=["Test"])
 api_router.include_router(hello.router, prefix="/hello", tags=["Hello"])
 api_router.include_router(adminInfo.router, prefix="/adminInfo", tags=["AdminInfo"])
 api_router.include_router(instance.router, prefix="/instance", tags=["Instance"])
+api_router.include_router(stack.router, prefix="/stacks", tags=["Stack"])

--- a/mcp-api-backend/api/v1/stack.py
+++ b/mcp-api-backend/api/v1/stack.py
@@ -1,0 +1,61 @@
+from fastapi import APIRouter, Query, Depends, HTTPException
+from sqlalchemy.orm import Session
+from service import instance_service, grafana_service
+from typing import Optional, List
+from api.api_response import *
+from db.connection import get_db, get_async_db
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    create_async_engine,
+    async_scoped_session,
+)
+from config.api_config import settings as api_settings  # for testing
+import logging
+
+from entity import stack_entity as schemas_stacks
+from entity import user_entity as schemas_users
+
+router = APIRouter()
+logger = logging.getLogger("uvicorn")
+
+
+from fastapi import APIRouter, Depends
+
+from service import stack_service
+
+router = APIRouter()
+
+
+@router.post("/", response_model=schemas_stacks.Stack)
+async def create_new_stack(
+    create_stack: schemas_stacks.StackCreate = Depends(stack_service.create_new_stack),
+):
+    return create_stack
+
+
+@router.patch("/{stack_id}", response_model=schemas_stacks.Stack)
+async def update_stack(
+    update_stack: schemas_stacks.StackCreate = Depends(stack_service.update_stack),
+):
+    return update_stack
+
+
+@router.get("/")
+async def get_all_stacks(
+    get_all_stacks: schemas_stacks.Stack = Depends(stack_service.get_all_stacks),
+):
+    return get_all_stacks
+
+
+@router.get("/{stack}")
+async def get_stack_by_id_or_name(
+    get_stack: schemas_stacks.Stack = Depends(stack_service.get_stack_by_id_or_name),
+):
+    return get_stack
+
+
+@router.delete("/{stack}")
+async def delete_stack_by_id_or_name(
+    delete_stack: schemas_stacks.Stack = Depends(stack_service.delete_stack_by_id_or_name),
+):
+    return delete_stack

--- a/mcp-api-backend/api/v1/stack.py
+++ b/mcp-api-backend/api/v1/stack.py
@@ -33,11 +33,11 @@ async def create_new_stack(
     return create_stack
 
 
-@router.patch("/{stack_id}", response_model=schemas_stacks.Stack)
-async def update_stack(
-    update_stack: schemas_stacks.StackCreate = Depends(stack_service.update_stack),
-):
-    return update_stack
+# @router.patch("/{stack_id}", response_model=schemas_stacks.Stack)
+# async def update_stack(
+#     update_stack: schemas_stacks.StackCreate = Depends(stack_service.update_stack),
+# ):
+#     return update_stack
 
 
 @router.get("/")

--- a/mcp-api-backend/config/celery_config.py
+++ b/mcp-api-backend/config/celery_config.py
@@ -1,0 +1,43 @@
+import os
+
+from celery import Celery
+
+celery_app = None
+# Rabbit broker config
+BROKER_USER = os.getenv("BROKER_USER", "admin")
+BROKER_PASSWD = os.getenv("BROKER_PASSWD", "admin")
+BROKER_SERVER = os.getenv("BROKER_SERVER", "127.0.0.1")  # use rabbit or redis
+BROKER_SERVER_PORT = os.getenv(
+    "BROKER_SERVER_PORT", "5672"
+)  # use por 6379 for redis or 5672 for RabbitMQ
+# use amqp for RabbitMQ or redis
+BROKER_TYPE = os.getenv("BROKER_TYPE", "amqp")
+# Redus backend config
+BACKEND_TYPE = os.getenv("BACKEND_TYPE", "redis")
+BACKEND_USER = os.getenv("BACKEND_USER", "")
+BACKEND_PASSWD = os.getenv("BACKEND_PASSWD", "")
+BACKEND_SERVER = os.getenv("BACKEND_SERVER", "127.0.0.1")
+BACKEND_DB = os.getenv("BACKEND_DB", "0")
+
+if not bool(os.getenv("DOCKER")):  # if running example without docker
+    celery_app = Celery(
+        "worker",
+        backend=f"{BACKEND_TYPE}://{BACKEND_USER}:{BACKEND_PASSWD}@{BACKEND_SERVER}/{BACKEND_DB}",
+        broker=f"{BROKER_TYPE}://{BROKER_USER}:{BROKER_PASSWD}@{BROKER_SERVER}:{BROKER_SERVER_PORT}//",
+        # broker=f"{BACKEND_TYPE}://{BROKER_USER}:{BROKER_PASSWD}@{BROKER_SERVER}:{BROKER_SERVER_PORT}//",
+    )
+    celery_app.conf.task_routes = {
+        "app.worker.celery_worker.test_celery": "api-queue"}
+    # celery_app.conf.task_routes = {"app.worker.celery_worker.test_celery": "127.0.0.1"}
+else:  # running example with docker
+    celery_app = Celery(
+        "worker",
+        backend=f"{BACKEND_TYPE}://{BACKEND_USER}:{BACKEND_PASSWD}@{BACKEND_SERVER}/{BACKEND_DB}",
+        broker=f"{BACKEND_TYPE}://{BROKER_USER}:{BROKER_PASSWD}@{BROKER_SERVER}:{BROKER_SERVER_PORT}//",
+    )
+    celery_app.conf.task_routes = {
+        "app.app.worker.celery_worker.test_celery": "api-queue"
+    }
+
+celery_app.conf.update(task_track_started=True)
+celery_app.conf.result_expires = os.getenv("MCP_RESULT_EXPIRE", "259200")

--- a/mcp-api-backend/db/model/stack_model.py
+++ b/mcp-api-backend/db/model/stack_model.py
@@ -1,0 +1,24 @@
+import datetime
+
+from db.session import Base
+from sqlalchemy import JSON, Column, DateTime, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+
+class Stack(Base):
+    __tablename__ = "stack"
+    stack_id = Column(Integer, primary_key=True, index=True)
+    stack_name = Column(String(50), unique=True)
+    stack_type = Column(String(50))
+    description = Column(Text())
+    var_list = Column(JSON)
+    var_json = Column(JSON)
+    team_access = Column(JSON)
+    tf_version = Column(String(30))
+    user_id = Column(Integer)
+    git_repo = Column(String(200))
+    branch = Column(String(50))
+    task_id = Column(String(200))
+    project_path = Column(String(50))
+    created_at = Column(DateTime, default=datetime.datetime.now())
+    # deploy = relationship("Deploy")

--- a/mcp-api-backend/entity/stack_entity.py
+++ b/mcp-api-backend/entity/stack_entity.py
@@ -5,12 +5,13 @@ from pydantic import BaseModel, Field, constr
 
 class StackBase(BaseModel):
     stack_name: constr(strip_whitespace=True)
-    git_repo: constr(strip_whitespace=True)
-    branch: constr(strip_whitespace=True) = "master"
+    stack_type: Optional[constr(strip_whitespace=True)]
+    description: constr(strip_whitespace=True)
     team_access: List[str] = ["*"]
     tf_version: constr(strip_whitespace=True) = "1.3.2"
+    git_repo: Optional[constr(strip_whitespace=True)]
+    branch: Optional[constr(strip_whitespace=True)] = "master"
     project_path: Optional[constr(strip_whitespace=True)] = Field("", example="")
-    description: constr(strip_whitespace=True)
 
     class Config:
         """Extra configuration options"""

--- a/mcp-api-backend/entity/stack_entity.py
+++ b/mcp-api-backend/entity/stack_entity.py
@@ -1,0 +1,36 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, constr
+
+
+class StackBase(BaseModel):
+    stack_name: constr(strip_whitespace=True)
+    git_repo: constr(strip_whitespace=True)
+    branch: constr(strip_whitespace=True) = "master"
+    team_access: List[str] = ["*"]
+    tf_version: constr(strip_whitespace=True) = "1.3.2"
+    project_path: Optional[constr(strip_whitespace=True)] = Field("", example="")
+    description: constr(strip_whitespace=True)
+
+    class Config:
+        """Extra configuration options"""
+
+        anystr_strip_whitespace = True  # remove trailing whitespace
+
+
+class StackCreate(StackBase):
+    pass
+
+    class Config:
+        """Extra configuration options"""
+
+        anystr_strip_whitespace = True  # remove trailing whitespace
+
+
+class Stack(StackBase):
+    stack_id: int
+    task_id: constr(strip_whitespace=True)
+    user_id: int
+
+    class Config:
+        orm_mode = True

--- a/mcp-api-backend/entity/stack_entity.py
+++ b/mcp-api-backend/entity/stack_entity.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 from pydantic import BaseModel, Field, constr
+import datetime
 
 
 class StackBase(BaseModel):
@@ -12,6 +13,7 @@ class StackBase(BaseModel):
     git_repo: Optional[constr(strip_whitespace=True)]
     branch: Optional[constr(strip_whitespace=True)] = "master"
     project_path: Optional[constr(strip_whitespace=True)] = Field("", example="")
+    created_at: Optional[datetime.datetime]
 
     class Config:
         """Extra configuration options"""

--- a/mcp-api-backend/main.py
+++ b/mcp-api-backend/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from api.v1.route import api_router
 from db.session import async_engine, engine
-from db.model import user_model, aws_cloudwatch_model
+from db.model import user_model, aws_cloudwatch_model, stack_model
 
 
 app = FastAPI(
@@ -20,6 +20,7 @@ async def init_tables():
     async with async_engine.begin() as conn:
         await conn.run_sync(user_model.Base.metadata.create_all)
         await conn.run_sync(aws_cloudwatch_model.Base.metadata.create_all)
+        await conn.run_sync(stack_model.Base.metadata.create_all)
 
 
 @app.get("/")

--- a/mcp-api-backend/repository/stack_repository.py
+++ b/mcp-api-backend/repository/stack_repository.py
@@ -19,6 +19,7 @@ def create_new_stack(
 ):
     db_stack = models.Stack(
         stack_name=stack.stack_name,
+        stack_type=stack.stack_type,
         git_repo=stack.git_repo,
         tf_version=stack.tf_version,
         project_path=stack.project_path,

--- a/mcp-api-backend/repository/stack_repository.py
+++ b/mcp-api-backend/repository/stack_repository.py
@@ -1,0 +1,165 @@
+import datetime
+
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+import entity.stack_entity as schemas
+import db.model.stack_model as models
+
+
+def create_new_stack(
+    db: Session,
+    stack: schemas.StackCreate,
+    user_id: int,
+    task_id: str,
+    var_json: str,
+    var_list: str,
+    team_access: str,
+):
+    db_stack = models.Stack(
+        stack_name=stack.stack_name,
+        git_repo=stack.git_repo,
+        tf_version=stack.tf_version,
+        project_path=stack.project_path,
+        description=stack.description,
+        branch=stack.branch,
+        user_id=user_id,
+        created_at=datetime.datetime.now(),
+        var_json=var_json,
+        var_list=var_list,
+        team_access=team_access,
+        task_id=task_id,
+    )
+    try:
+        db.add(db_stack)
+        db.commit()
+        db.refresh(db_stack)
+        return db_stack
+    except IntegrityError:
+        raise HTTPException(
+            status_code=409, detail="The stack name already exist")
+    except Exception as err:
+        raise err
+
+
+def update_stack(
+    db: Session,
+    stack: schemas.StackCreate,
+    stack_id: int,
+    user_id: int,
+    task_id: str,
+    var_json: str,
+    var_list: str,
+    team_access: str,
+):
+    db_stack = db.query(models.Stack).filter(
+        models.Stack.stack_id == stack_id).first()
+
+    db_stack.user_id = user_id
+    db_stack.task_id = task_id
+    db_stack.var_json = var_json
+    db_stack.var_list = var_list
+    db_stack.updated_at = datetime.datetime.now()
+    check_None = ["string", ""]
+    if db_stack.stack_name not in check_None:
+        db_stack.stack_name = stack.stack_name
+    if db_stack.git_repo not in check_None:
+        db_stack.git_repo = stack.git_repo
+    if db_stack.branch not in check_None:
+        db_stack.branch = stack.branch
+    if db_stack.tf_version not in check_None:
+        db_stack.tf_version = stack.tf_version
+    if db_stack.project_path not in check_None:
+        db_stack.project_path = stack.project_path
+    if db_stack.description not in check_None:
+        db_stack.description = stack.description
+    if db_stack.team_access not in check_None:
+        db_stack.team_access = team_access
+    try:
+        db.add(db_stack)
+        db.commit()
+        db.refresh(db_stack)
+        return db_stack
+    except Exception as err:
+        raise err
+
+
+def get_all_stacks_by_team(
+    db: Session, team_access: str, skip: int = 0, limit: int = 100
+):
+    try:
+        filter_all = (
+            db.query(models.Stack)
+            .filter(models.Stack.team_access.contains("*"))
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+        from sqlalchemy import func
+
+        result = []
+        for i in team_access:
+            a = f'["{i}"]'
+            result.extend(
+                db.query(models.Stack)
+                .filter(func.json_contains(models.Stack.team_access, a) == 1)
+                .all()
+            )
+        merge_query = result + filter_all
+        return set(merge_query)
+    except Exception as err:
+        raise err
+
+
+def get_all_stacks(db: Session, skip: int = 0, limit: int = 100):
+    try:
+        return db.query(models.Stack).offset(skip).limit(limit).all()
+    except Exception as err:
+        raise err
+
+
+def get_stack_by_id(db: Session, stack_id: int):
+    try:
+        return db.query(models.Stack).filter(models.Stack.stack_id == stack_id).first()
+    except Exception as err:
+        raise err
+
+
+def delete_stack_by_id(db: Session, stack_id: int):
+    try:
+        db.query(models.Stack).filter(models.Stack.stack_id == stack_id).delete()
+        db.commit()
+        return {"result": "deleted", "stack_id": stack_id}
+    except IntegrityError:
+        raise HTTPException(
+            status_code=409,
+            detail="The stack cannot be removed, check that it is not used by any deploy",
+        )
+    except Exception as err:
+        raise err
+
+
+def get_stack_by_name(db: Session, stack_name: str):
+    try:
+        return (
+            db.query(models.Stack).filter(
+                models.Stack.stack_name == stack_name).first()
+        )
+    except Exception as err:
+        raise err
+
+
+def delete_stack_by_name(db: Session, stack_name: str):
+    try:
+        db.query(models.Stack).filter(
+            models.Stack.stack_name == stack_name).delete()
+        db.commit()
+        return {"result": "deleted", "stack_name": stack_name}
+    except IntegrityError:
+        raise HTTPException(
+            status_code=409,
+            detail="The stack cannot be removed, check that it is not used by any deploy",
+        )
+    except Exception as err:
+        raise err

--- a/mcp-api-backend/service/stack_service.py
+++ b/mcp-api-backend/service/stack_service.py
@@ -1,0 +1,241 @@
+from fastapi import APIRouter, Query, Depends, HTTPException
+
+# from src.activityLogs.infrastructure import repositories as crud_activity
+# from src.shared.helpers.get_data import check_team_stack, check_providers
+from utils.utils import sync_git
+from src.shared.security import deps
+from entity import stack_entity as schemas_stacks
+from entity import user_entity as schemas_users
+from db.connection import get_db
+from repository import stack_repository as crud_stacks
+from sqlalchemy.orm import Session
+import logging
+import random
+
+
+router = APIRouter()
+logger = logging.getLogger("uvicorn")
+
+
+async def create_new_stack(
+    stack: schemas_stacks.StackCreate,
+    current_user: schemas_users.User = Depends(deps.get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    logger.info("create_new_stack 진입...")
+    name = "default"
+    environment = "default"
+    team = "team"
+    branch = stack.branch
+
+    # Checkif stack name providers are supperted
+    # check_providers(stack_name=stack.stack_name) TODO: 프로바이더 prefix로 validation 필요
+    # logger.info("check_providers 반환...")
+
+    # Check if stack exist
+    db_stack = crud_stacks.get_stack_by_name(db, stack_name=stack.stack_name)
+    logger.info("get_stack_by_name 반환...")
+    if db_stack:
+        raise HTTPException(
+            status_code=409, detail="The stack name already exist")
+    
+
+    # Check if the user have permissions for create stack
+    # check_team_stack(db, current_user, current_user.team, stack.team_access) TODO: team_access validation 필요
+    # logger.info("check_team_stack 반환...")
+    
+    
+    # Push git task to queue team, all workers are subscribed to this queue
+    task = sync_git(
+        stack_name=stack.stack_name,
+        git_repo=stack.git_repo,
+        branch=branch,
+        project_path=stack.project_path,
+        environment=environment,
+        team=team,
+        name=name,
+    )
+    logger.info("sync_git 반환...")
+    variables_list = [i for i in task[1]["variable"].keys()]
+    try:
+        # pesrsist data in db
+        result = crud_stacks.create_new_stack(
+            db=db,
+            stack=stack,
+            # user_id=current_user.id,
+            user_id=random.randint(0, 10000000),  # TODO: user_id 넣기
+            task_id=task[0],
+            var_json=task[1],
+            var_list=variables_list,
+            team_access=stack.team_access,
+        )
+
+        # crud_activity.create_activity_log(
+        #     db=db,
+        #     username=current_user.username,
+        #     team=current_user.team,
+        #     action=f"Create Stack {stack.stack_name}",
+        # )
+        return result
+    except Exception as err:
+        raise HTTPException(status_code=409, detail=f"Duplicate entry {err}")
+
+
+async def delete_stack_by_id_or_name(
+    stack,
+    current_user: schemas_users.User = Depends(deps.get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    try:
+        if not stack.isdigit():
+            result = crud_stacks.get_stack_by_name(db=db, stack_name=stack)
+            if result is None:
+                raise HTTPException(status_code=404, detail="Stack id not found")
+            # Check if the user have permissions for delete stack
+            # check_team_stack(db, current_user, current_user.team, result.team_access)
+
+            # crud_activity.create_activity_log(
+            #     db=db,
+            #     username=current_user.username,
+            #     team=current_user.team,
+            #     action=f"Delete Stack {result.stack_name}",
+            # )
+            return crud_stacks.delete_stack_by_name(db=db, stack_name=stack)
+
+        result = crud_stacks.get_stack_by_id(db=db, stack_id=stack)
+        if result is None:
+            raise HTTPException(status_code=404, detail="Stack id not found")
+
+        # Check if the user have permissions for create stack
+        # check_team_stack(db, current_user, current_user.team, result.team_access)
+
+        # crud_activity.create_activity_log(
+        #     db=db,
+        #     username=current_user.username,
+        #     team=current_user.team,
+        #     action=f"Delete Stack {result.id}",
+        # )
+        return crud_stacks.delete_stack_by_id(db=db, stack_id=stack)
+    except Exception as err:
+        raise err
+
+
+async def get_all_stacks(
+    current_user: schemas_users.User = Depends(deps.get_current_active_user),
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+):
+    # TODO: 사용자 권한 validation 필요
+    # if not crud_users.is_master(db, current_user):
+    #     return crud_stacks.get_all_stacks_by_team(
+    #         db=db, team_access=current_user.team, skip=skip, limit=limit
+    #     )
+    return crud_stacks.get_all_stacks(
+        db=db, skip=skip, limit=limit
+    )
+
+
+async def get_stack_by_id_or_name(
+    stack,
+    current_user: schemas_users.User = Depends(deps.get_current_active_user),
+    db: Session = Depends(get_db),
+):
+
+    if not stack.isdigit():
+        result = crud_stacks.get_stack_by_name(db=db, stack_name=stack)
+        # if not crud_users.is_master(db, current_user):
+        #     if result is None:
+        #         raise HTTPException(
+        #             status_code=404, detail="stack id not found")
+        #     if (
+        #         not check_team_user(current_user.team, result.team_access)
+        #         and not "*" in result.team_access
+        #     ):
+        #         raise HTTPException(
+        #             status_code=403,
+        #             detail=f"Not enough permissions in {result.team_access}",
+        #         )
+        return result
+
+    result = crud_stacks.get_stack_by_id(db=db, stack_id=stack)
+    if result is None:
+        raise HTTPException(status_code=404, detail="stack id not found")
+    
+    # TODO: 사용자 권한 validation 필요
+    # if not crud_users.is_master(db, current_user):
+    #     if (
+    #         not check_team_user(current_user.team, result.team_access)
+    #         and not "*" in result.team_access
+    #     ):
+    #         raise HTTPException(
+    #             status_code=403,
+    #             detail=f"Not enough permissions in {result.team_access}",
+    #         )
+    return result
+
+
+async def update_stack(
+    stack_id: int,
+    stack: schemas_stacks.StackCreate,
+    current_user: schemas_users.User = Depends(deps.get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    name = "default"
+    environment = "default"
+    team = "team"
+    branch = stack.branch
+
+    # Check if the user have permissions for create stack
+    # check_team_stack(db, current_user, current_user.team, stack.team_access)
+    # Checkif stack name providers are supperted
+    # check_providers(stack_name=stack.stack_name)
+    
+    
+    # Check if stack exist
+    db_stack = crud_stacks.get_stack_by_id(db, stack_id=stack_id)
+    
+    
+    # Check if stack used by deploy TODO: deploy 사용중인 stack은 수정 불가
+    # if db_stack.stack_name != stack.stack_name:
+    #     deploy = crud_deploy.get_deploy_by_stack(
+    #         db=db, stack_name=db_stack.stack_name)
+    #     if deploy is not None:
+    #         raise HTTPException(
+    #             status_code=409, detail=f"The stack is being used by {deploy.name}"
+    #         )
+
+
+    # Push git task to queue team, all workers are subscribed to this queue
+    task = sync_git(
+        stack_name=stack.stack_name,
+        git_repo=stack.git_repo,
+        branch=branch,
+        project_path=stack.project_path,
+        environment=environment,
+        team=team,
+        name=name,
+    )
+    variables_list = [i for i in task[1]["variable"].keys()]
+    try:
+        # pesrsist data in db
+        result = crud_stacks.update_stack(
+            db=db,
+            stack_id=stack_id,
+            stack=stack,
+            user_id=current_user.id,
+            task_id=task[0],
+            var_json=task[1],
+            var_list=variables_list,
+            team_access=stack.team_access,
+        )
+
+        # crud_activity.create_activity_log(
+        #     db=db,
+        #     username=current_user.username,
+        #     team=current_user.team,
+        #     action=f"Update Stack {stack.stack_name}",
+        # )
+        return result
+    except Exception as err:
+        raise HTTPException(status_code=409, detail=f"Duplicate entry {err}")

--- a/mcp-api-backend/src/shared/security/deps.py
+++ b/mcp-api-backend/src/shared/security/deps.py
@@ -1,3 +1,7 @@
 """
 의존성 관리 모듈
 """
+def get_current_active_user():
+    ...
+    import random
+    return random.randint(1, 100000000)

--- a/mcp-api-backend/src/terraform_template/aws/vpc/output.tf
+++ b/mcp-api-backend/src/terraform_template/aws/vpc/output.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+    value = aws_vpc.vpc.id
+}
+
+output "cidr_ip" {
+    value = aws_vpc.vpc.cidr_block
+}
+
+output "owner_id" {
+    value = aws_vpc.vpc.owner_id
+}

--- a/mcp-api-backend/src/terraform_template/aws/vpc/vpc_variable.tf
+++ b/mcp-api-backend/src/terraform_template/aws/vpc/vpc_variable.tf
@@ -14,7 +14,7 @@ variable "aws_vpc_name" {
 variable "aws_dns_support_flag" {
     type = bool
     description = "VPC의 dns support 활성화/비활성화 여부를 true/false 로 입력하세요."
-    default = "aws vpc name"
+    default = true
 }
 
 # Internet Gateway

--- a/mcp-api-backend/src/worker/provider.py
+++ b/mcp-api-backend/src/worker/provider.py
@@ -1,0 +1,191 @@
+# DI terraform provider
+from src.worker.providers.hashicorp.actions import Actions, SimpleActions
+from src.worker.providers.hashicorp.artifact import *
+from src.worker.providers.hashicorp.download import BinaryDownload
+from src.worker.providers.hashicorp.templates import Backend, GetVars, Tfvars
+
+
+class ProviderRequirements:
+    """
+    ProviderActions가 실행되기 위해 필요한 모든 것들을 생성하는 클래스
+    """
+
+    # terraform binary 다운로드
+    def binary_download(version, binary=BinaryDownload):
+        config_binary = binary(version)
+        return config_binary.get()
+
+    # git repo에서 tf 파일 다운로드
+    def artifact_download(
+        name: str,
+        stack_name: str,
+        environment: str,
+        team: str,
+        git_repo: str,
+        branch: str,
+        project_path: str = "",
+        artifact=ArtifactFromGit,
+    ) -> dict:
+        config_artifact = artifact(
+            name, stack_name, environment, team, git_repo, branch, project_path
+        )
+        return config_artifact.get()
+    
+    # 내부 tf 템플릿 파일 복사
+    def artifact_copy(
+        name: str,
+        stack_name: str,
+        stack_type: str,
+        environment: str,
+        team: str,
+        artifact=ArtifactFromTemplate,
+    ) -> dict:
+        config_artifact = artifact(
+            name, stack_name, environment, team, stack_type
+        )
+        return config_artifact.get()
+
+    def storage_state(
+        name: str,
+        stack_name: str,
+        environment: str,
+        team: str,
+        project_path: str,
+        backend=Backend,
+    ) -> dict:
+        config_backend = backend(name, stack_name, environment, team, project_path)
+        return config_backend.save()
+
+    def parameter_vars(
+        name: str,
+        stack_name: str,
+        environment: str,
+        team: str,
+        project_path: str,
+        kwargs: dict,
+        vars=Tfvars,
+    ) -> dict:
+        config_vars = vars(name, stack_name, environment, team, project_path, kwargs)
+        return config_vars.save()
+
+
+class ProviderGetVars:
+    """
+    provider vairables에서 정보를 얻기 위한 클래스
+    """
+
+    def json_vars(
+        name: str,
+        stack_name: str,
+        stack_type: str,
+        environment: str,
+        team: str,
+        project_path: str="",
+        vars=GetVars,
+    ) -> dict:
+        config_vars = vars(name, stack_name, stack_type, environment, team, project_path)
+        return config_vars.get_vars_json()
+
+
+class ProviderActions:
+    """
+    terraform deploy 시 각 action에 대응되는 메소드를 가지고 있는 클래스
+    """
+
+    # terraform plan
+    def plan(
+        name: str,
+        stack_name: str,
+        branch: str,
+        environment: str,
+        team: str,
+        version: str,
+        secreto: dict,
+        variables_file: str = "",
+        project_path: str = "",
+        action=Actions,
+    ) -> dict:
+        config_action = action(
+            name,
+            stack_name,
+            branch,
+            environment,
+            team,
+            version,
+            secreto,
+            variables_file,
+            project_path,
+        )
+        return config_action.plan_execute()
+
+    # terraform apply
+    def apply(
+        name: str,
+        stack_name: str,
+        branch: str,
+        environment: str,
+        team: str,
+        version: str,
+        secreto: dict,
+        variables_file: str = "",
+        project_path: str = "",
+        action=Actions,
+    ) -> dict:
+        config_action = action(
+            name,
+            stack_name,
+            branch,
+            environment,
+            team,
+            version,
+            secreto,
+            variables_file,
+            project_path,
+        )
+        return config_action.apply_execute()
+
+    # terraform destroy
+    def destroy(
+        name: str,
+        stack_name: str,
+        branch: str,
+        environment: str,
+        team: str,
+        version: str,
+        secreto: dict,
+        variables_file: str = "",
+        project_path: str = "",
+        action=Actions,
+    ) -> dict:
+        config_action = action(
+            name,
+            stack_name,
+            branch,
+            environment,
+            team,
+            version,
+            secreto,
+            variables_file,
+            project_path,
+        )
+        return config_action.destroy_execute()
+
+    # terraform output
+    def output(
+        stack_name: str, team: str, environment: str, name: str, action=SimpleActions
+    ) -> dict:
+        config_action = action(stack_name, team, environment, name)
+        return config_action.output_execute()
+
+    def unlock(
+        stack_name: str, team: str, environment: str, name: str, action=SimpleActions
+    ) -> dict:
+        config_action = action(stack_name, team, environment, name)
+        return config_action.unlock_execute()
+
+    # terraform show
+    def show(
+        stack_name: str, team: str, environment: str, name: str, action=SimpleActions
+    ) -> dict:
+        config_action = action(stack_name, team, environment, name)
+        return config_action.show_execute()

--- a/mcp-api-backend/src/worker/providers/hashicorp/actions.py
+++ b/mcp-api-backend/src/worker/providers/hashicorp/actions.py
@@ -1,0 +1,310 @@
+import os
+import subprocess
+from dataclasses import dataclass
+
+import jmespath
+import requests
+from config.api_config import settings
+
+# from src.worker.security.providers_credentials import secret, unsecret
+
+
+@dataclass
+class StructBase:
+    name: str
+    stack_name: str
+    branch: str
+    environment: str
+    team: str
+
+
+@dataclass
+class Actions(StructBase):
+    version: str
+    secreto: dict
+    variables_file: str
+    project_path: str
+    """
+    In this class are all the methods equivalent to the terraform commands
+    """
+
+    def plan_execute(self) -> dict:
+        try:
+            secret(
+                self.stack_name, self.environment, self.team, self.name, self.secreto
+            )
+            deploy_state = (
+                f"{self.environment}_{self.stack_name}_{self.team}_{self.name}"
+            )
+            # Execute task
+            variables_files = (
+                f"{self.stack_name}.tfvars.json"
+                if self.variables_file == "" or self.variables_file == None
+                else self.variables_file
+            )
+
+            if not self.project_path:
+                os.chdir(
+                    f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}"
+                )
+            os.chdir(
+                f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}"
+            )
+            result = subprocess.run(
+                f"/tmp/{self.version}/terraform init -input=false --upgrade",
+                shell=True,
+                capture_output=True,
+                encoding="utf8",
+            )
+            result = subprocess.run(
+                f"/tmp/{self.version}/terraform plan -input=false -refresh -no-color -var-file={variables_files} -out={self.stack_name}.tfplan",
+                shell=True,
+                capture_output=True,
+                encoding="utf8",
+            )
+            unsecret(
+                self.stack_name, self.environment, self.team, self.name, self.secreto
+            )
+
+            # Capture events
+            rc = result.returncode
+            # check result
+            if rc != 0:
+                return {
+                    "command": "plan",
+                    "deploy": self.name,
+                    "team": self.team,
+                    "stack_name": self.stack_name,
+                    "environment": self.environment,
+                    "rc": rc,
+                    "tfvars_files": self.variables_file,
+                    "remote_state": f"http://127.0.0.1:8080/terraform_state/{deploy_state}",
+                    "project_path": f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}",
+                    "stdout": [result.stderr.split("\n")],
+                }
+            return {
+                "command": "plan",
+                "deploy": self.name,
+                "team": self.team,
+                "stack_name": self.stack_name,
+                "environment": self.environment,
+                "rc": rc,
+                "tfvars_files": self.variables_file,
+                "remote_state": f"http://127.0.0.1:8080/terraform_state/{deploy_state}",
+                "project_path": f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}",
+                "stdout": [result.stdout.split("\n")],
+            }
+        except Exception:
+            return {
+                "command": "plan",
+                "deploy": self.name,
+                "team": self.team,
+                "stack_name": self.stack_name,
+                "environment": self.environment,
+                "rc": rc,
+                "tfvars_files": self.variables_file,
+                "remote_state": f"http://127.0.0.1:8080/terraform_state/{deploy_state}",
+                "project_path": f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}",
+                "stdout": [result.stderr.split("\n")],
+            }
+
+    def apply_execute(self) -> dict:
+        try:
+            secret(
+                self.stack_name, self.environment, self.team, self.name, self.secreto
+            )
+            deploy_state = (
+                f"{self.environment}_{self.stack_name}_{self.team}_{self.name}"
+            )
+            # Execute task
+
+            if not self.project_path:
+                os.chdir(
+                    f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}"
+                )
+            os.chdir(
+                f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}"
+            )
+
+            result = subprocess.run(
+                f"/tmp/{self.version}/terraform init -input=false --upgrade",
+                shell=True,
+                capture_output=True,
+                encoding="utf8",
+            )
+            result = subprocess.run(
+                f"/tmp/{self.version}/terraform apply -input=false -auto-approve -no-color {self.stack_name}.tfplan",
+                shell=True,
+                capture_output=True,
+                encoding="utf8",
+            )
+            unsecret(
+                self.stack_name, self.environment, self.team, self.name, self.secreto
+            )
+
+            # Capture events
+            rc = result.returncode
+            # check result
+            if rc != 0:
+                return {
+                    "command": "apply",
+                    "deploy": self.name,
+                    "self.team": self.team,
+                    "self.stack_name": self.stack_name,
+                    "self.environment": self.environment,
+                    "rc": rc,
+                    "tfvars_files": self.variables_file,
+                    "remote_state": f"http://127.0.0.1:8080/terraform_state/{deploy_state}",
+                    "self.project_path": f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}",
+                    "stdout": [result.stderr.split("\n")],
+                }
+            return {
+                "command": "apply",
+                "deploy": self.name,
+                "self.team": self.team,
+                "self.stack_name": self.stack_name,
+                "self.environment": self.environment,
+                "rc": rc,
+                "tfvars_files": self.variables_file,
+                "self.project_path": f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}",
+                "remote_state": f"http://127.0.0.1:8080/terraform_state/{deploy_state}",
+                "stdout": [result.stdout.split("\n")],
+            }
+        except Exception:
+            return {
+                "command": "apply",
+                "deploy": self.name,
+                "self.team": self.team,
+                "self.stack_name": self.stack_name,
+                "self.environment": self.environment,
+                "rc": 1,
+                "tfvars_files": self.variables_file,
+                "self.project_path": f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}",
+                "remote_state": f"http://127.0.0.1:8080/terraform_state/{deploy_state}",
+                "stdout": "ko",
+            }
+
+    def destroy_execute(self) -> dict:
+        try:
+            secret(
+                self.stack_name, self.environment, self.team, self.name, self.secreto
+            )
+            deploy_state = (
+                f"{self.environment}_{self.stack_name}_{self.team}_{self.name}"
+            )
+            # Execute task
+            variables_files = (
+                f"{self.stack_name}.tfvars.json"
+                if self.variables_file == "" or self.variables_file == None
+                else self.variables_file
+            )
+            if not self.project_path:
+                os.chdir(
+                    f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}"
+                )
+            os.chdir(
+                f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}"
+            )
+
+            result = subprocess.run(
+                f"/tmp/{self.version}/terraform init -input=false --upgrade",
+                shell=True,
+                capture_output=True,
+                encoding="utf8",
+            )
+            result = subprocess.run(
+                f"/tmp/{self.version}/terraform destroy -input=false -auto-approve -no-color -var-file={variables_files}",
+                shell=True,
+                capture_output=True,
+                encoding="utf8",
+            )
+            unsecret(
+                self.stack_name, self.environment, self.team, self.name, self.secreto
+            )
+            # Capture events
+            rc = result.returncode
+            # check result
+            if rc != 0:
+                return {
+                    "command": "destroy",
+                    "deploy": self.name,
+                    "self.team": self.team,
+                    "self.stack_name": self.stack_name,
+                    "self.environment": self.environment,
+                    "rc": rc,
+                    "tfvars_files": self.variables_file,
+                    "remote_state": f"http://127.0.0.1:8080/terraform_state/{deploy_state}",
+                    "self.project_path": f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}",
+                    "stdout": [result.stderr.split("\n")],
+                }
+            return {
+                "command": "destroy",
+                "deploy": self.name,
+                "self.team": self.team,
+                "self.stack_name": self.stack_name,
+                "self.environment": self.environment,
+                "rc": rc,
+                "tfvars_files": self.variables_file,
+                "self.project_path": f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}",
+                "remote_state": f"http://127.0.0.1:8080/terraform_state/{deploy_state}",
+                "stdout": [result.stdout.split("\n")],
+            }
+        except Exception:
+            return {
+                "command": "destroy",
+                "deploy": self.name,
+                "self.team": self.team,
+                "self.stack_name": self.stack_name,
+                "self.environment": self.environment,
+                "rc": 1,
+                "tfvars_files": self.variables_file,
+                "self.project_path": f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}",
+                "remote_state": f"http://127.0.0.1:8080/terraform_state/{deploy_state}",
+                # "stdout": [result.stderr.split("\n")],
+                "stdout": "ko",
+            }
+
+
+@dataclass
+class SimpleActions:
+    stack_name: str
+    team: str
+    environment: str
+    name: str
+
+    def output_execute(self):
+        try:
+            get_path = f"{self.stack_name}-{self.team}-{self.environment}-{self.name}"
+            print(get_path)
+            response = requests.get(
+                f"{settings.REMOTE_STATE}/terraform_state/{get_path}"
+            )
+            json_data = response.json()
+            result = json_data.get("outputs")
+            if not result:
+                result = jmespath.search("modules[*].outputs", json_data)
+            return result
+        except Exception as err:
+            return {"command": "output", "rc": 1, "stdout": err}
+
+    def unlock_execute(self):
+        try:
+            get_path = f"{self.stack_name}-{self.team}-{self.environment}-{self.name}"
+            response = requests.delete(
+                f"{settings.REMOTE_STATE}/terraform_lock/{get_path}", json={}
+            )
+            return response.json()
+        except Exception as err:
+            return {"command": "unlock", "rc": 1, "stdout": err}
+
+    def show_execute(self):
+        try:
+            get_path = f"{self.stack_name}-{self.team}-{self.environment}-{self.name}"
+            print(get_path)
+            response = requests.get(
+                f"{settings.REMOTE_STATE}/terraform_state/{get_path}"
+            )
+            json_data = response.json()
+            return json_data
+        except Exception as err:
+            return {"command": "show", "rc": 1, "stdout": err}

--- a/mcp-api-backend/src/worker/providers/hashicorp/artifact.py
+++ b/mcp-api-backend/src/worker/providers/hashicorp/artifact.py
@@ -1,0 +1,118 @@
+import logging
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from os import listdir
+from os.path import isfile, join
+
+logger = logging.getLogger("uvicorn")
+
+@dataclass
+class StructBase:
+    name: str
+    stack_name: str
+    environment: str
+    team: str
+
+
+@dataclass
+class ArtifactFromGit(StructBase):
+    git_repo: str
+    branch: str
+    project_path: str
+
+    def get(self):
+
+        try:
+            directory = f"/tmp/{self.stack_name}/{self.environment}/{self.team}/"
+            os.makedirs(directory, exist_ok=True)
+            logger.info(f"Directory {directory} created successfully")
+        except OSError:
+            logger.info(f"Directory {directory} can not be created")
+
+        try:
+            if os.path.exists(f"{directory}/{self.name}"):
+                shutil.rmtree(f"{directory}/{self.name}")
+
+            logger.info(f"Download git repo {self.git_repo} branch {self.branch}")
+            os.chdir(directory)
+
+            result = subprocess.run(
+                f"git clone --recurse-submodules --branch {self.branch} {self.git_repo} {self.name}",
+                shell=True,
+                capture_output=True,
+                encoding="utf8",
+            )
+
+            logger.info(f"Check if variable.tf file exist")
+
+            tfvars_files = [
+                f
+                for f in listdir(directory)
+                if f.endswith(".tfvars") and isfile(join(directory, f))
+            ]
+
+            rc = result.returncode
+            if rc != 0:
+                return {
+                    "command": "git",
+                    "rc": rc,
+                    "tfvars": tfvars_files,
+                    "stdout": result.stderr,
+                }
+            return {
+                "command": "git",
+                "rc": rc,
+                "tfvars": tfvars_files,
+                "stdout": result.stdout,
+            }
+        except Exception as err:
+            return {"command": "git", "rc": 1, "tfvars": tfvars_files, "stdout": err}
+
+
+@dataclass
+class ArtifactFromTemplate(StructBase):
+    stack_type: str
+
+    def get(self):
+
+        try:
+            directory = f"/tmp/{self.stack_name}/{self.environment}/{self.team}/"
+            os.makedirs(directory, exist_ok=True)
+            logger.info(f"Directory {directory} created successfully")
+        except OSError:
+            logger.info(f"Directory {directory} can not be created")
+
+        try:
+            if os.path.exists(f"{directory}/{self.name}/{self.stack_type}"):
+                shutil.rmtree(f"{directory}/{self.name}/{self.stack_type}")
+
+            logger.info(f"Copy template {self.stack_type}")
+            shutil.copytree(f"./src/terraform_template/aws/{self.stack_type}", f"{directory}/{self.name}/{self.stack_type}")
+
+            logger.info(f"Check if (stack_type)_variable.tf file exist")
+
+            tfvars_files = [
+                f
+                for f in listdir(directory)
+                if f.endswith(".tfvars") and isfile(join(directory, f))
+            ]
+            print(tfvars_files)
+
+            # rc = result.returncode
+            # if rc != 0:
+            #     return {
+            #         "command": "template",
+            #         "rc": rc,
+            #         "tfvars": tfvars_files,
+            #         # "stdout": result.stderr,
+            #     }
+            return {
+                "command": "template",
+                "rc": 0,
+                "tfvars": tfvars_files,
+                # "stdout": result.stdout,
+            }
+        except Exception as err:
+            return {"command": "template", "rc": 1, "tfvars": tfvars_files, "stdout": err}

--- a/mcp-api-backend/src/worker/providers/hashicorp/download.py
+++ b/mcp-api-backend/src/worker/providers/hashicorp/download.py
@@ -1,0 +1,36 @@
+import os
+import stat
+import zipfile
+from io import BytesIO
+
+import requests
+from urllib3.exceptions import InsecureRequestWarning
+
+requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+from config.api_config import settings
+
+
+class BinaryDownload:
+    def __init__(self, version):
+        self.version = version
+
+    def get(self) -> dict:
+        # 테라폼 바이너리 다운로드
+        binary = f"{settings.TERRAFORM_BIN_REPO}/{self.version}/terraform_{self.version}_darwin_arm64.zip"
+        try:
+            if not os.path.exists(f"/tmp/{self.version}"):
+                os.mkdir(f"/tmp/{self.version}")
+            if not os.path.isfile(f"/tmp/{self.version}/terraform"):
+                req = requests.get(binary, verify=False)
+                _zipfile = zipfile.ZipFile(BytesIO(req.content))
+                _zipfile.extractall(f"/tmp/{self.version}")
+                st = os.stat(f"/tmp/{self.version}/terraform")
+                os.chmod(f"/tmp/{self.version}/terraform", st.st_mode | stat.S_IEXEC)
+            return {
+                "command": "binaryDownload",
+                "rc": 0,
+                "stdout": "Download Binary file",
+            }
+
+        except Exception as err:
+            return {"command": "binaryDownload", "rc": 1, "stdout": err}

--- a/mcp-api-backend/src/worker/providers/hashicorp/templates.py
+++ b/mcp-api-backend/src/worker/providers/hashicorp/templates.py
@@ -1,0 +1,103 @@
+import json
+from dataclasses import dataclass
+
+import hcl
+from jinja2 import Template
+
+
+@dataclass
+class StructBase:
+    name: str
+    stack_name: str
+    stack_type: str
+    environment: str
+    team: str
+
+
+@dataclass
+class Backend(StructBase):
+    project_path: str
+
+    def save(self) -> dict:
+        # data = """
+        # terraform {
+        #   backend "http" {
+        #     address = "http://remote-state:8080/terraform_state/{{deploy_state}}"
+        #     lock_address = "http://remote-state:8080/terraform_lock/{{deploy_state}}"
+        #     lock_method = "PUT"
+        #     unlock_address = "http://remote-state:8080/terraform_lock/{{deploy_state}}"
+        #     unlock_method = "DELETE"
+        #   }
+        # }
+        # """
+        data = """
+        terraform {
+          backend "http" {
+            address = "http://127.0.0.1:8080/terraform_state/{{deploy_state}}"
+            lock_address = "http://127.0.0.1:8080/terraform_lock/{{deploy_state}}"
+            lock_method = "PUT"
+            unlock_address = "http://127.0.0.1:8080/terraform_lock/{{deploy_state}}"
+            unlock_method = "DELETE"
+          }
+        }
+        """
+        try:
+            tm = Template(data)
+            provider_backend = tm.render(
+                deploy_state=f"{self.stack_name}-{self.team}-{self.environment}-{self.name}"
+            )
+            file_path = f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.stack_name}-{self.name}-{self.environment}.tf"
+            if self.project_path:
+                file_path = f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}/{self.stack_name}-{self.name}-{self.environment}.tf"
+            with open(file_path, "w") as tf_state:
+                tf_state.write(provider_backend)
+            return {"command": "tfserver", "rc": 0, "stdout": data}
+        except Exception as err:
+            return {"command": "tfserver", "rc": 1, "stderr": err}
+
+
+@dataclass
+class Tfvars(StructBase):
+    project_path: str
+    kwargs: dict
+
+    def save(self) -> dict:
+        try:
+            file_path = f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.stack_name}.tfvars.json"
+            if self.project_path:
+                file_path = f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}/{self.stack_name}.tfvars.json"
+            with open(file_path, "w") as tfvars_json:
+                json.dump(self.kwargs, tfvars_json)
+            return {"command": "tfvars", "rc": 0, "stdout": self.kwargs}
+        except Exception as err:
+            return {"command": "tfvars", "rc": 1, "stdout": f"{err}"}
+
+
+@dataclass
+class GetVars(StructBase):
+    project_path: str
+    """
+    In this class are the methods to obtain information from the terraform variables
+    """
+
+    def __set_path(self):
+        if not self.project_path:
+            return f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.stack_type}/{self.stack_type}_variable.tf"
+        return f"/tmp/{self.stack_name}/{self.environment}/{self.team}/{self.name}/{self.project_path}/variable.tf"
+
+    def get_vars_json(self) -> dict:
+        try:
+            file_hcl = self.__set_path()
+            print(f"{file_hcl=}")
+            with open(file_hcl, "r") as fp:
+                obj = hcl.load(fp)
+            if obj.get("variable"):
+                return {"command": "get_vars_json", "rc": 0, "stdout": json.dumps(obj, ensure_ascii=False)}
+            else:
+                error_msg = "Variable file is empty, not iterable"
+                return {"command": "get_vars_json", "rc": 1, "stdout": error_msg}
+        except IOError:
+            error_msg = "Variable file not accessible"
+            return {"command": "get_vars_json", "rc": 1, "stdout": error_msg}
+        except Exception as err:
+            return {"command": "get_vars_json", "rc": 1, "stdout": err}

--- a/mcp-api-backend/src/worker/tasks/helpers/schedule.py
+++ b/mcp-api-backend/src/worker/tasks/helpers/schedule.py
@@ -1,0 +1,45 @@
+# import datetime
+
+# # from dateutil import parser
+# import requests
+# from config.api_config import settings
+# from fastapi import HTTPException
+
+# server = settings.SCHEDULE_SERVER
+
+
+# def resource_life_cycle(start_time: str, end_time: str) -> bool:
+#     if start_time == 0:
+#         return None
+#     date.today().weekday()
+#     parser_start_time = parser.parse(start_time)
+#     parser_end_time = parser.parse(end_time)
+
+#     now = datetime.datetime.now()
+#     now_param = datetime.time(now.hour, now.minute, 0)
+#     start = parser_start_time.time()
+#     end = parser_end_time.time()
+
+#     """Return true if now_param is in the range [start, end]"""
+#     if start <= end:
+#         return start <= now_param <= end
+#     else:
+#         return start <= now_param or now_param <= end
+
+
+# def request_url(verb: str, headers: dict = "", uri: str = "", json: dict = ""):
+#     response = requests.request(verb, headers=headers, url=f"{server}/{uri}", json=json)
+#     try:
+#         result = {
+#             "status_code": response.status_code,
+#             "content": response.content.decode("utf-8"),
+#             "json": response.json(),
+#         }
+#         return result
+#     except Exception as err:
+#         raise HTTPException(status_code=501, detail=f"{err}")
+
+
+# def check_status():
+#     response = request_url(verb="GET")
+#     return response

--- a/mcp-api-backend/src/worker/tasks/terraform_worker.py
+++ b/mcp-api-backend/src/worker/tasks/terraform_worker.py
@@ -1,0 +1,562 @@
+import logging
+import traceback
+
+import redis
+from celery import states
+from celery.exceptions import Ignore
+from celery.utils.log import get_task_logger
+from config.api_config import settings
+from config.celery_config import celery_app
+
+from src.worker.provider import ProviderActions, ProviderGetVars, ProviderRequirements
+# from src.worker.tasks.helpers.folders import Utils
+# from src.worker.tasks.helpers.metrics import push_metric
+# from src.worker.tasks.helpers.schedule import request_url
+
+# r = redis.Redis(
+#     host=settings.BACKEND_SERVER,
+#     port=6379,
+#     db=2,
+#     charset="utf-8",
+#     decode_responses=True,
+# )
+
+logger = get_task_logger(__name__)
+
+
+# @celery_app.task(
+#     bind=True, acks_late=True, time_limit=settings.DEPLOY_TMOUT, name="pipeline Deploy"
+# )
+# @push_metric()
+# def pipeline_deploy(
+#     self,
+#     git_repo: str,
+#     name: str,
+#     stack_name: str,
+#     environment: str,
+#     team: str,
+#     branch: str,
+#     version: str,
+#     kwargs: any,
+#     secreto: str,
+#     variables_file: str = "",
+#     project_path: str = "",
+#     user: str = "",
+# ):
+#     try:
+#         logger.info(
+#             f"[DEPLOY] User {user} launch deploy {name} with stack {stack_name} on team {team} and environment {environment}"
+#         )
+#         r.set(f"{name}-{team}-{environment}", "Locked")
+#         logger.info(f"[DEPLOY] lock sld {name}-{team}-{environment}")
+#         r.expire(f"{name}-{team}-{environment}", settings.TASK_LOCKED_EXPIRED)
+#         logger.info(
+#             f"[DEPLOY] set sld {name}-{team}-{environment} expire timeout {settings.TASK_LOCKED_EXPIRED}"
+#         )
+#         # Git clone repo
+#         logger.info(
+#             f"[DEPLOY] User {user} launch deploy {name} with stack {stack_name} on team {team} and environment {environment} git pull"
+#         )
+#         result = ProviderRequirements.artifact_download(
+#             name, stack_name, environment, team, git_repo, branch
+#         )
+
+#         self.update_state(state="PULLING", meta={"done": "1 of 6"})
+#         if result["rc"] != 0:
+#             logger.error(
+#                 f"[DEPLOY] Error when user {user} launch deploy {name} with stack {stack_name} on team {team} and environment {environment} git pull"
+#             )
+#             raise Exception(result)
+#         # Download terrafom
+#         logger.info(
+#             f"[DEPLOY] User {user} launch deploy {name} with stack {stack_name} on team {team} and environment {environment} download terrafom version {version}"
+#         )
+#         result = ProviderRequirements.binary_download(version)
+
+#         self.update_state(state="LOADBIN", meta={"done": "2 of 6"})
+#         # Delete artifactory to avoid duplicating the runner logs
+#         if result["rc"] != 0:
+#             logger.error(
+#                 f"[DEPLOY] Error when User {user} launch deploy {name} with stack {stack_name} on team {team} and environment {environment} download terrafom version {version}"
+#             )
+#             raise Exception(result)
+
+#         # Create tf to use the custom backend state
+#         self.update_state(state="REMOTECONF", meta={"done": "3 of 6"})
+
+#         result = ProviderRequirements.storage_state(
+#             name, stack_name, environment, team, project_path
+#         )
+#         if result["rc"] != 0:
+#             raise Exception(result)
+
+#         # Create tfvar serialize with json
+#         self.update_state(state="SETVARS", meta={"done": "4 of 6"})
+#         result = ProviderRequirements.parameter_vars(
+#             name, stack_name, environment, team, project_path, kwargs
+#         )
+#         if result["rc"] != 0:
+#             raise Exception(result)
+#         # Plan execute
+#         logger.info(
+#             f"[DEPLOY] User {user} launch deploy {name} with stack {stack_name} on team {team} and environment {environment} terraform plan"
+#         )
+#         self.update_state(state="PLANNING", meta={"done": "5 of 6"})
+#         result = ProviderActions.plan(
+#             name,
+#             stack_name,
+#             branch,
+#             environment,
+#             team,
+#             version,
+#             secreto,
+#             variables_file,
+#             project_path,
+#         )
+
+#         if result["rc"] != 0:
+#             logger.error(
+#                 f"[DEPLOY] Error when User {user} launch deploy {name} with stack {stack_name} on team {team} and environment {environment} execute terraform plan"
+#             )
+#             raise Exception(result)
+#         # Apply execute
+#         logger.info(
+#             f"[DEPLOY] User {user} launch deploy {name} with stack {stack_name} on team {team} and environment {environment} terraform apply with timeout deploy setting {settings.DEPLOY_TMOUT}"
+#         )
+#         self.update_state(state="APPLYING", meta={"done": "6 of 6"})
+#         result = ProviderActions.apply(
+#             name,
+#             stack_name,
+#             branch,
+#             environment,
+#             team,
+#             version,
+#             secreto,
+#             variables_file,
+#             project_path,
+#         )
+#         if result["rc"] != 0:
+#             logger.error(
+#                 f"[DEPLOY] Error when User {user} launch deploy {name} with stack {stack_name} on team {team} and environment {environment} download terrafom version {version}"
+#             )
+#             raise Exception(result)
+#         return result
+#     except Exception as err:
+#         if not settings.ROLLBACK:
+#             logger.error(
+#                 f"[DEPLOY] Error when User {user} launch deploy {name} with stack {stack_name} on team {team} and environment {environment} download terrafom version {version} execute Retry"
+#             )
+#             self.retry(
+#                 countdown=settings.TASK_RETRY_INTERVAL,
+#                 exc=err,
+#                 max_retries=settings.TASK_MAX_RETRY,
+#             )
+#             self.update_state(state=states.FAILURE, meta={"exc": result})
+#             raise Ignore()
+#             logger.error(
+#                 f"[DEPLOY] Error when User {user} launch deploy {name} with stack {stack_name} on team {team} and environment {environment} download terrafom version {version} execute RollBack"
+#             )
+#         self.update_state(state="ROLLBACK", meta={"done": "1 of 1"})
+#         destroy_result = ProviderActions.destroy(
+#             name,
+#             stack_name,
+#             branch,
+#             environment,
+#             team,
+#             version,
+#             secreto,
+#             variables_file,
+#             project_path,
+#         )
+#         self.update_state(
+#             state=states.FAILURE,
+#             meta={
+#                 "exc_type": type(err).__name__,
+#                 "exc_message": traceback.format_exc().split("\n"),
+#             },
+#         )
+#         raise Ignore()
+#     finally:
+#         dir_path = f"/tmp/{ stack_name }/{environment}/{team}/{name}"
+#         r.delete(f"{name}-{team}-{environment}")
+#         if not settings.DEBUG:
+#             Utils.delete_local_folder(dir_path)
+
+
+# @celery_app.task(bind=True, acks_late=True, name="pipeline Destroy")
+# @push_metric()
+# def pipeline_destroy(
+#     self,
+#     git_repo: str,
+#     name: str,
+#     stack_name: str,
+#     environment: str,
+#     team: str,
+#     branch: str,
+#     version: str,
+#     kwargs: any,
+#     secreto: str,
+#     variables_file: str = "",
+#     project_path: str = "",
+#     user: str = "",
+# ):
+#     try:
+#         logger.info(
+#             f"User {user} launch destroy {name} with stack {stack_name} on team {team} and environment {environment}"
+#         )
+#         r.set(f"{name}-{team}-{environment}", "Locked")
+#         logger.info(f"lock sld {name}-{team}-{environment}")
+#         r.expire(f"{name}-{team}-{environment}", settings.TASK_LOCKED_EXPIRED)
+#         logger.info(
+#             f"set sld {name}-{team}-{environment} expire timeout {settings.TASK_LOCKED_EXPIRED}"
+#         )
+#         # Git clone repo
+#         logger.info(
+#             f"User {user} Destroy deploy {name} with stack {stack_name} on team {team} and environment {environment} git pull"
+#         )
+#         result = ProviderRequirements.artifact_download(
+#             name, stack_name, environment, team, git_repo, branch
+#         )
+#         self.update_state(state="PULLING", meta={"done": "1 of 6"})
+#         if result["rc"] != 0:
+#             raise Exception(result)
+#         # Download terrafom
+#         logger.info(
+#             f"User {user} Destroy deploy {name} with stack {stack_name} on team {team} and environment {environment} download terrafom version {version}"
+#         )
+#         result = ProviderRequirements.binary_download(version)
+#         self.update_state(state="LOADBIN", meta={"done": "2 of 6"})
+#         # Delete artifactory to avoid duplicating the runner logs
+#         if result["rc"] != 0:
+#             logger.error(
+#                 f"Error when User {user} launch destroy {name} with stack {stack_name} on team {team} and environment {environment} download terrafom version {version}"
+#             )
+#             raise Exception(result)
+#         # Create tf to use the custom backend storage state
+#         self.update_state(state="REMOTECONF", meta={"done": "3 of 6"})
+#         result = ProviderRequirements.storage_state(
+#             name, stack_name, environment, team, project_path
+#         )
+#         if result["rc"] != 0:
+#             raise Exception(result)
+#         # Create tfvar serialize with json
+#         self.update_state(state="SETVARS", meta={"done": "4 of 6"})
+#         result = ProviderRequirements.parameter_vars(
+#             name, stack_name, environment, team, project_path, kwargs
+#         )
+#         if result["rc"] != 0:
+#             raise Exception(result)
+
+#         logger.info(
+#             f"User {user} launch destroy {name} with stack {stack_name} on team {team} and environment {environment} execute destroy"
+#         )
+#         self.update_state(state="DESTROYING", meta={"done": "6 of 6"})
+#         result = ProviderActions.destroy(
+#             name,
+#             stack_name,
+#             branch,
+#             environment,
+#             team,
+#             version,
+#             secreto,
+#             variables_file,
+#             project_path,
+#         )
+#         if result["rc"] != 0:
+#             raise Exception(result)
+#         return result
+#     except Exception as err:
+#         self.retry(countdown=5, exc=err, max_retries=1)
+#         self.update_state(state=states.FAILURE, meta={"exc": result})
+#         raise Ignore()
+#     finally:
+#         dir_path = f"/tmp/{ stack_name }/{environment}/{team}/{name}"
+#         Utils.delete_local_folder(dir_path)
+#         r.delete(f"{name}-{team}-{environment}")
+
+
+# @celery_app.task(bind=True, acks_late=True, name="pipeline Plan")
+# @push_metric()
+# def pipeline_plan(
+#     self,
+#     git_repo: str,
+#     name: str,
+#     stack_name: str,
+#     environment: str,
+#     team: str,
+#     branch: str,
+#     version: str,
+#     kwargs: any,
+#     secreto: str,
+#     variables_file: str = "",
+#     project_path: str = "",
+#     user: str = "",
+# ):
+#     try:
+#         r.set(f"{name}-{team}-{environment}", "Locked")
+#         logger.info(f"[DEPLOY] lock sld {name}-{team}-{environment}")
+#         r.expire(f"{name}-{team}-{environment}", settings.TASK_LOCKED_EXPIRED)
+#         logger.info(
+#             f"User {user} launch plan {name} with stack {stack_name} on team {team} and environment {environment}"
+#         )
+#         self.update_state(state="GIT", meta={"done": "1 of 5"})
+#         result = ProviderRequirements.artifact_download(
+#             name, stack_name, environment, team, git_repo, branch
+#         )
+#         if result["rc"] != 0:
+#             logger.error(
+#                 f"Error when user {user} launch plan {name} with stack {stack_name} on team {team} and environment {environment} git pull"
+#             )
+#             raise Exception(result)
+#         self.update_state(state="BINARY", meta={"done": "2 of 5"})
+#         logger.info(
+#             f"User {user} launch plan {name} with stack {stack_name} on team {team} and environment {environment} download terrafom version {version}"
+#         )
+#         result = ProviderRequirements.binary_download(version)
+#         if result["rc"] != 0:
+#             logger.error(
+#                 f"Error when User {user} launch plan {name} with stack {stack_name} on team {team} and environment {environment} download terrafom version {version}"
+#             )
+#             raise Exception(result)
+
+#         self.update_state(state="REMOTE", meta={"done": "3 of 5"})
+#         result = ProviderRequirements.storage_state(
+#             name, stack_name, environment, team, project_path
+#         )
+#         if result["rc"] != 0:
+#             raise Exception(result)
+
+#         self.update_state(state="VARS", meta={"done": "4 of 5"})
+#         result = ProviderRequirements.parameter_vars(
+#             name, stack_name, environment, team, project_path, kwargs
+#         )
+#         if result["rc"] != 0:
+#             raise Exception(result)
+
+#         self.update_state(state="PLAN", meta={"done": "5 of 5"})
+#         result = ProviderActions.plan(
+#             name,
+#             stack_name,
+#             branch,
+#             environment,
+#             team,
+#             version,
+#             secreto,
+#             variables_file,
+#             project_path,
+#         )
+#         if result["rc"] != 0:
+#             logger.error(
+#                 f"Error when User {user} launch plan {name} with stack {stack_name} on team {team} and environment {environment} execute terraform plan"
+#             )
+#             raise Exception(result)
+#         return result
+#     except Exception as err:
+#         self.retry(countdown=5, exc=err, max_retries=1)
+#         self.update_state(state=states.FAILURE, meta={"exc": result})
+#         raise Ignore()
+#     finally:
+#         dir_path = f"/tmp/{ stack_name }/{environment}/{team}/{name}"
+#         Utils.delete_local_folder(dir_path)
+#         r.delete(f"{name}-{team}-{environment}")
+
+
+@celery_app.task(
+    bind=True, acks_late=True, time_limit=30, name="pipeline git pull"
+)
+def pipeline_git_pull(
+    self,
+    git_repo: str,
+    name: str,
+    stack_name: str,
+    environment: str,
+    team: str,
+    branch: str,
+    project_path: str,
+):
+    try:
+        git_result = ProviderRequirements.artifact_download(
+            name, stack_name, environment, team, git_repo, branch, project_path
+        )
+        if git_result["rc"] != 0:
+            raise Exception(git_result.get("stdout"))
+
+        self.update_state(state="GET_VARS_AS_JSON", meta={"done": "2 of 2"})
+        result = ProviderGetVars.json_vars(
+            environment=environment,
+            stack_name=stack_name,
+            team=team,
+            name=name,
+            project_path=project_path,
+        )
+        if result["rc"] != 0:
+            raise Exception(result.get("stdout"))
+        result["tfvars"] = git_result["tfvars"]
+        return result
+    except Exception as err:
+        self.retry(countdown=1, exc=err, max_retries=settings.TASK_MAX_RETRY)
+        self.update_state(state=states.FAILURE, meta={"exc": result})
+        raise Ignore()
+    finally:
+        dir_path = f"/tmp/{ stack_name }/{environment}/{team}/{name}"
+        print(dir_path)
+
+
+@celery_app.task(
+    bind=True, acks_late=True, time_limit=30, name="pipeline copy template"
+)
+def pipeline_copy_template(
+    self,
+    name: str,
+    stack_name: str,
+    stack_type: str,
+    environment: str,
+    team: str,
+):
+    try:
+        copy_result = ProviderRequirements.artifact_copy(
+            name=name, stack_name=stack_name, stack_type=stack_type, environment=environment, team=team
+        )
+        if copy_result["rc"] != 0:
+            raise Exception(copy_result.get("stdout"))
+    
+        print(copy_result)
+
+        self.update_state(state="GET_VARS_AS_JSON", meta={"done": "2 of 2"})
+        result = ProviderGetVars.json_vars(
+            environment=environment,
+            stack_name=stack_name,
+            stack_type=stack_type,
+            team=team,
+            name=name,
+        )
+        if result["rc"] != 0:
+            raise Exception(result.get("stdout"))
+        result["tfvars"] = copy_result["tfvars"]
+
+        return result
+    except Exception as err:
+        self.retry(countdown=1, exc=err, max_retries=settings.TASK_MAX_RETRY)
+        self.update_state(state=states.FAILURE, meta={"exc": result})
+        raise Ignore()
+
+@celery_app.task(
+    bind=True, acks_late=True, time_limit=30, name="download git repo"
+)
+def git(
+    self,
+    git_repo: str,
+    name: str,
+    stack_name: str,
+    environment: str,
+    team: str,
+    branch: str,
+):
+    try:
+        result = ProviderRequirements.artifact_download(
+            name, stack_name, environment, team, git_repo, branch
+        )
+    except Exception as err:
+        self.retry(
+            countdown=30, exc=err, max_retries=settings.TASK_MAX_RETRY
+        )
+        self.update_state(state=states.FAILURE, meta={"exc": result})
+        raise Ignore()
+    return stack_name, environment, team, name, result
+
+
+# @celery_app.task(
+#     bind=True,
+#     acks_late=True,
+#     time_limit=settings.WORKER_TMOUT,
+#     max_retries=1,
+#     name="terraform output",
+# )
+# def output(self, stack_name: str, team: str, environment: str, name: str):
+#     try:
+#         output_result = ProviderActions.output(stack_name, team, environment, name)
+#         return output_result
+#     except Exception as err:
+#         return {"stdout": err}
+#     finally:
+#         dir_path = f"/tmp/{ stack_name }/{environment}/{team}/{name}"
+#         Utils.delete_local_folder(dir_path)
+
+
+# @celery_app.task(
+#     bind=True,
+#     acks_late=True,
+#     time_limit=settings.WORKER_TMOUT,
+#     max_retries=1,
+#     name="terraform unlock",
+# )
+# def unlock(self, stack_name: str, team: str, environment: str, name: str):
+#     try:
+#         unlock_result = ProviderActions.unlock(stack_name, team, environment, name)
+#         return unlock_result
+#     except Exception as err:
+#         return {"stdout": err}
+
+
+# @celery_app.task(
+#     bind=True, acks_late=True, time_limit=settings.WORKER_TMOUT, name="terraform show"
+# )
+# def show(self, stack_name: str, team: str, environment: str, name: str):
+#     show_result = ProviderActions.show(stack_name, team, environment, name)
+#     return show_result
+
+
+# @celery_app.task(
+#     bind=True, acks_late=True, time_limit=settings.WORKER_TMOUT, name="schedules list"
+# )
+# def schedules_list(self):
+#     try:
+#         return request_url(verb="GET", uri=f"schedules/").get("json")
+#     except Exception:
+#         pass
+
+
+# @celery_app.task(
+#     bind=True, acks_late=True, time_limit=settings.WORKER_TMOUT, name="schedule get"
+# )
+# def schedule_get(self, deploy_name: str):
+#     try:
+#         return request_url(verb="GET", uri=f"schedule/{deploy_name}").get("json")
+#     except Exception:
+#         pass
+
+
+# @celery_app.task(
+#     bind=True, acks_late=True, time_limit=settings.WORKER_TMOUT, name="schedule remove"
+# )
+# def schedule_delete(self, deploy_name: str):
+#     try:
+#         return request_url(verb="DELETE", uri=f"schedule/{deploy_name}").get("json")
+#     except Exception:
+#         pass
+
+
+# @celery_app.task(
+#     bind=True, acks_late=True, time_limit=settings.WORKER_TMOUT, name="schedule add"
+# )
+# def schedule_add(self, deploy_name: str):
+#     try:
+#         return request_url(verb="POST", uri=f"schedule/{deploy_name}").get("json")
+#     except Exception as err:
+#         return err
+
+
+# @celery_app.task(
+#     bind=True,
+#     acks_late=True,
+#     time_limit=settings.WORKER_TMOUT,
+#     max_retries=1,
+#     name="Update schedule",
+# )
+# def schedule_update(self, deploy_name: str):
+#     try:
+#         request_url(verb="DELETE", uri=f"schedule/{deploy_name}")
+#         return request_url(verb="POST", uri=f"schedule/{deploy_name}").get("json")
+#     except Exception as err:
+#         logging.warning(request_url(verb="POST", uri=f"schedule/{deploy_name}"))
+#         return err

--- a/mcp-api-backend/utils/utils.py
+++ b/mcp-api-backend/utils/utils.py
@@ -1,4 +1,76 @@
 from sqlalchemy import inspect
+from src.worker.tasks.terraform_worker import (
+    # output,
+    # pipeline_deploy,
+    # pipeline_destroy,
+    pipeline_git_pull,
+    pipeline_copy_template,
+    # pipeline_plan,
+    # schedule_add,
+    # schedule_delete,
+    # schedule_get,
+    # schedule_update,
+    # schedules_list,
+    # show,
+    # unlock,
+)
+import json
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 def object_as_dict(obj):
     return {c.key: getattr(obj, c.key) for c in inspect(obj).mapper.column_attrs}
+
+
+def sync_git(
+    stack_name: str,
+    git_repo: str,
+    branch: str,
+    project_path: str,
+    environment: str,
+    team: str,
+    name: str,
+):
+    try:
+        pipeline_git_result = pipeline_git_pull.s(
+            stack_name=stack_name,
+            git_repo=git_repo,
+            branch=branch,
+            project_path=project_path,
+            environment=environment,
+            team=team,
+            name=name,
+        ).apply_async(queue="team")
+        task_id = pipeline_git_result.task_id
+        get_data = pipeline_git_result.get()
+        try:
+            data = json.loads(get_data.get("stdout"))
+        except Exception:
+            raise ValueError(get_data.get("result"))
+        return task_id, data
+    except Exception as err:
+        raise HTTPException(status_code=408, detail=f"{err}")
+
+def copy_template(
+    stack_name: str,
+    stack_type: str,
+    environment: str,
+    team: str,
+    name: str,
+):
+    try:
+        pipeline_copy_result = pipeline_copy_template.s(
+            stack_name=stack_name,
+            stack_type=stack_type,
+            environment=environment,
+            team=team,
+            name=name,
+        ).apply_async(queue="team")
+        task_id = pipeline_copy_result.task_id
+        get_data = pipeline_copy_result.get()
+        try:
+            data = json.loads(get_data.get("stdout"))
+        except Exception:
+            raise ValueError(get_data.get("result"))
+        return task_id, data
+    except Exception as err:
+        raise HTTPException(status_code=408, detail=f"{err}")


### PR DESCRIPTION
#6 테라폼 코드 파싱

파싱 로직 작성을 위해 임시로 스택 모델, 엔티티, 컨트롤러, 레포지토리 추가
스택 생성 시 `/tmp/{stack_name}/{env}/{team}/{name}/{stack_type}` 에 해당하는 스택의 `.tf` 파일들이 템플릿에서 복사됨

템플릿을 사용한 스택 update 로직은 작성되지 않았으므로 현재 엔드포인트 비활성화 상태 (다른 이슈 생성 후 추가 구현 필요)

구동 시 Cerely worker 실행이 필요함

`celery --app src.worker.tasks.terraform_worker worker --loglevel=info -c 8 -E -Q any,team,team1,team2`

Celery auto reload 할 필요가 있을 때는
`watchmedo auto-restart --directory=./ --pattern="*.py" --recursive -- celery --app src.worker.tasks.terraform_worker worker --loglevel=info -c 8 -E -Q any,team,team1,team2`